### PR TITLE
Adding the encoded (jwt) token to the socket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ function noQsMethod(options) {
         // success handler
         var onSuccess = function() {
           socket[options.decodedPropertyName] = decoded;
+          socket.encoded_token = data.token; //Adding the encoded token to the socket.
           socket.emit('authenticated');
           if (server.$emit) {
             server.$emit('authenticated', socket);


### PR DESCRIPTION
The JWT-Token is often required on the serverside after authentication (API Scenario) -In this approach it is  saved under socket.encoded_token.