### PR TITLE
Added option to store encoded jwt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,9 @@ function noQsMethod(options) {
         return onError({message: 'invalid token datatype'}, 'invalid_token');
       }
 
+      // Store encoded JWT
+      socket[options.encodedPropertyName] = token;
+
       var onJwtVerificationReady = function(err, decoded) {
 
         if (err) {
@@ -105,7 +108,7 @@ function noQsMethod(options) {
 }
 
 function authorize(options, onConnection) {
-  options = xtend({ decodedPropertyName: 'decoded_token' }, options);
+  options = xtend({ decodedPropertyName: 'decoded_token', encodedPropertyName: 'encoded_token' }, options);
 
   if (!options.handshake) {
     return noQsMethod(options);
@@ -166,6 +169,9 @@ function authorize(options, onConnection) {
       });
       return auth.fail(error, data, accept);
     }
+
+    // Store encoded JWT
+    socket[options.encodedPropertyName] = token;
 
     var onJwtVerificationReady = function(err, decoded) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -171,7 +171,7 @@ function authorize(options, onConnection) {
     }
 
     // Store encoded JWT
-    socket[options.encodedPropertyName] = token;
+    data[options.encodedPropertyName] = token;
 
     var onJwtVerificationReady = function(err, decoded) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ function noQsMethod(options) {
       }
 
       // Store encoded JWT
-      socket[options.encodedPropertyName] = token;
+      socket[options.encodedPropertyName] = data.token;
 
       var onJwtVerificationReady = function(err, decoded) {
 


### PR DESCRIPTION
As in issue #115 described, we also do need access to the encoded jwt.

To achieve this, we should keep the api clean. Therefore we should use an option like we do with `decodedPropertyName`, which defaults to `decoded_token`. There is now the option `encodedPropertyName`, which defaults to `encoded_token`.

This works without and with the handshake, in contrast to PR #115.